### PR TITLE
Add type hints

### DIFF
--- a/src/Bridge/SluggableInterface.php
+++ b/src/Bridge/SluggableInterface.php
@@ -14,7 +14,7 @@ interface SluggableInterface
      * In that case, no validation will be performed and any
      * (dummy) slug will be accepted.
      *
-     * @return string|null
+     * @return ?string
      */
     public function getSlug();
 }

--- a/src/DependencyInjection/WebfactorySlugValidationExtension.php
+++ b/src/DependencyInjection/WebfactorySlugValidationExtension.php
@@ -9,10 +9,7 @@ use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 
 class WebfactorySlugValidationExtension extends Extension
 {
-    /**
-     * {@inheritdoc}
-     */
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $container): void
     {
         $loader = new YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.yml');

--- a/src/EventListener/ValidateSlugListener.php
+++ b/src/EventListener/ValidateSlugListener.php
@@ -35,7 +35,7 @@ class ValidateSlugListener implements EventSubscriberInterface
      */
     private $urlGenerator = null;
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             KernelEvents::CONTROLLER => ['onKernelController', self::PRIORITY_AFTER_PARAM_CONVERTER_LISTENER],
@@ -52,7 +52,7 @@ class ValidateSlugListener implements EventSubscriberInterface
      *
      * If an invalid slug is detected, then the user will be redirected to the URLs with the valid slug.
      */
-    public function onKernelController(ControllerEvent $event)
+    public function onKernelController(ControllerEvent $event): void
     {
         $attributes = $event->getRequest()->attributes;
         foreach ($attributes as $name => $value) {
@@ -68,12 +68,7 @@ class ValidateSlugListener implements EventSubscriberInterface
         }
     }
 
-    /**
-     * @param string $objectParameterName
-     *
-     * @return RedirectResponse
-     */
-    private function createRedirectFor(Request $request, $objectParameterName)
+    private function createRedirectFor(Request $request, string $objectParameterName): RedirectResponse
     {
         /* @var $object SluggableInterface */
         $object = $request->attributes->get($objectParameterName);
@@ -90,10 +85,8 @@ class ValidateSlugListener implements EventSubscriberInterface
 
     /**
      * @param string $name Name of the checked parameter.
-     *
-     * @return bool
      */
-    private function hasValidSlug(ParameterBag $attributes, $name)
+    private function hasValidSlug(ParameterBag $attributes, string $name): bool
     {
         $object = $attributes->get($name);
         if (!($object instanceof SluggableInterface)) {
@@ -116,12 +109,8 @@ class ValidateSlugListener implements EventSubscriberInterface
 
     /**
      * Returns the name of the parameter that could contain the slug for $parameter.
-     *
-     * @param string $parameter
-     *
-     * @return string
      */
-    private function getSlugParameterNameFor($parameter)
+    private function getSlugParameterNameFor(string $parameter): string
     {
         return $parameter.'Slug';
     }

--- a/tests/EventListener/ValidateSlugListenerTest.php
+++ b/tests/EventListener/ValidateSlugListenerTest.php
@@ -34,7 +34,7 @@ class ValidateSlugListenerTest extends TestCase
     /**
      * @test
      */
-    public function isEventSubscriber()
+    public function isEventSubscriber(): void
     {
         $this->assertInstanceOf(EventSubscriberInterface::class, $this->listener);
     }
@@ -42,7 +42,7 @@ class ValidateSlugListenerTest extends TestCase
     /**
      * @test
      */
-    public function listenerDoesNotRedirectIfRequestContainsNoObjects()
+    public function listenerDoesNotRedirectIfRequestContainsNoObjects(): void
     {
         $event = $this->createEvent();
         $originalController = $event->getController();
@@ -55,7 +55,7 @@ class ValidateSlugListenerTest extends TestCase
     /**
      * @test
      */
-    public function listenerDoesNotRedirectIfRequestContainsObjectButNoSlugIsRequired()
+    public function listenerDoesNotRedirectIfRequestContainsObjectButNoSlugIsRequired(): void
     {
         $event = $this->createEvent();
         $event->getRequest()->attributes->set('object', $this->createSluggableObject(null));
@@ -69,7 +69,7 @@ class ValidateSlugListenerTest extends TestCase
     /**
      * @test
      */
-    public function listenerDoesNotRedirectIfRequestContainsValidSlugForObject()
+    public function listenerDoesNotRedirectIfRequestContainsValidSlugForObject(): void
     {
         $object = $this->createSluggableObject('my-slug');
         $event = $this->createEvent();
@@ -85,7 +85,7 @@ class ValidateSlugListenerTest extends TestCase
     /**
      * @test
      */
-    public function listenerRedirectsIfRequestContainsInvalidSlugForObject()
+    public function listenerRedirectsIfRequestContainsInvalidSlugForObject(): void
     {
         $event = $this->createEvent();
         $event->getRequest()->attributes->set('_route', 'test');
@@ -106,7 +106,7 @@ class ValidateSlugListenerTest extends TestCase
      *
      * @test
      */
-    public function listenerStopsEventPropagationIfRedirectIsNecessary()
+    public function listenerStopsEventPropagationIfRedirectIsNecessary(): void
     {
         $event = $this->createEvent();
         $event->getRequest()->attributes->set('object', $this->createSluggableObject('real-slug'));
@@ -120,7 +120,7 @@ class ValidateSlugListenerTest extends TestCase
     /**
      * @test
      */
-    public function listenerAddsCorrectSlugToUrlIfNecessary()
+    public function listenerAddsCorrectSlugToUrlIfNecessary(): void
     {
         $event = $this->createEvent();
         $object = $this->createSluggableObject('real-slug');
@@ -144,7 +144,7 @@ class ValidateSlugListenerTest extends TestCase
      *
      * @test
      */
-    public function listenerDoesNotRedirectIfObjectHasNoSlug()
+    public function listenerDoesNotRedirectIfObjectHasNoSlug(): void
     {
         $event = $this->createEvent();
         $object = $this->createSluggableObject(null);
@@ -159,12 +159,8 @@ class ValidateSlugListenerTest extends TestCase
 
     /**
      * Simulates an object that provides the given slug.
-     *
-     * @param string|null $slug
-     *
-     * @return SluggableInterface
      */
-    private function createSluggableObject($slug)
+    private function createSluggableObject(?string $slug): SluggableInterface
     {
         $object = $this->createMock(SluggableInterface::class);
         $object->expects($this->any())
@@ -192,7 +188,7 @@ class ValidateSlugListenerTest extends TestCase
      *
      * @return MockObject&HttpKernelInterface
      */
-    private function createKernel()
+    private function createKernel(): HttpKernelInterface
     {
         return $this->createMock(HttpKernelInterface::class);
     }
@@ -209,10 +205,8 @@ class ValidateSlugListenerTest extends TestCase
 
     /**
      * Creates a URL generator for testing.
-     *
-     * @return UrlGeneratorInterface
      */
-    private function createUrlGenerator()
+    private function createUrlGenerator(): UrlGeneratorInterface
     {
         $generator = $this->createMock(UrlGeneratorInterface::class);
         // Create a dummy URL that contains relevant provided data.


### PR DESCRIPTION
By adding return type hints, we can avoid some deprecation notices emitted by Symfony.