### PR TITLE
Use PHP 8 Syntax, drop PHP 7 support (Case 178313)

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -10,7 +10,7 @@ on:
     pull_request:
 
 env:
-    PHP_VERSION: 7.4
+    PHP_VERSION: 8.0
 
 jobs:
     composer-require-checker:

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -10,7 +10,7 @@ on:
     pull_request:
 
 env:
-    PHP_VERSION: 8.0
+    PHP_VERSION: 8.3
 
 jobs:
     composer-require-checker:

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -36,4 +36,4 @@ jobs:
             -   run: |
                     composer install --no-interaction --no-progress --ansi --no-scripts
                     composer show
-            -   uses: docker://webfactory/composer-require-checker:3.2.0
+            -   uses: docker://webfactory/composer-require-checker:4.5.0

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,9 +18,6 @@ jobs:
             fail-fast: false
             matrix:
                 include:
-                    - { php-version: 7.2, symfony-locked-version: none, dependency-version: prefer-lowest }
-                    - { php-version: 7.4, symfony-locked-version: 5.3.*, dependency-version: prefer-stable }
-                    - { php-version: 7.4, symfony-locked-version: none, dependency-version: prefer-stable }
                     - { php-version: 8.1, symfony-locked-version: none, dependency-version: prefer-stable }
                     - { php-version: 8.2, symfony-locked-version: none, dependency-version: prefer-stable }
                     - { php-version: 8.3, symfony-locked-version: none, dependency-version: prefer-stable }

--- a/README.md
+++ b/README.md
@@ -132,4 +132,4 @@ This project was started at webfactory GmbH, Bonn.
 - <https://www.webfactory.de>
 - <https://twitter.com/webfactory>
 
-Copyright 2016-2019 webfactory GmbH, Bonn. Code released under [the MIT license](LICENSE).
+Copyright 2016-2025 webfactory GmbH, Bonn. Code released under [the MIT license](LICENSE).

--- a/README.md
+++ b/README.md
@@ -40,7 +40,9 @@ Enable the bundle:
 ## Usage ##
 
 *Prerequisite*: In order to be able to use the slug validation provided by this bundle,
-you have to load your sluggable objects via a [param converter](http://symfony.com/doc/current/bundles/SensioFrameworkExtraBundle/annotations/converters.html).
+you have to load your sluggable objects outside of the controller action, e.g. via a
+[param converter](http://symfony.com/doc/current/bundles/SensioFrameworkExtraBundle/annotations/converters.html),
+so that the object is provided as a parameter to the action method.  
 For Doctrine entities Symfony brings this capability out of the box.
 
 ### Request Your Entity via Param Converter ###

--- a/README.md
+++ b/README.md
@@ -26,20 +26,16 @@ Install the bundle via [Composer](https://getcomposer.org):
 
     composer require webfactory/slug-validation-bundle
 
-Enable the bundle in your kernel:
+Enable the bundle:
 
     <?php
-    // app/AppKernel.php
+    // src/bundles.php
 
-    public function registerBundles()
-    {
-        $bundles = array(
-            // ...
-            new \Webfactory\SlugValidationBundle\WebfactorySlugValidationBundle(),
-            // ...
-        );
+    return [
         // ...
-    }
+        Webfactory\SlugValidationBundle\WebfactorySlugValidationBundle::class => ['all' => true],
+        // ...
+    ];
 
 ## Usage ##
 

--- a/README.md
+++ b/README.md
@@ -62,10 +62,7 @@ Provide the hint that the entity has a slug that can be validated by implementin
 
     class MyEntity implements SluggableInterface
     {
-        /**
-         * @return string|null
-         */
-        public function getSlug()
+        public function getSlug(): ?string
         {
             return 'my-generated-slug';
         }

--- a/composer.json
+++ b/composer.json
@@ -13,13 +13,13 @@
     ],
 
     "require": {
-        "php": "7.2.*|7.3.*|7.4.*|8.0.*|8.1.*|8.2.*|8.3.*",
-        "symfony/config": "^3.4|^4.0|^5.0|^6.0|^7.0",
-        "symfony/dependency-injection": "^3.4|^4.0|^5.0|^6.0|^7.0",
-        "symfony/event-dispatcher": "^3.4|^4.0|^5.0|^6.0|^7.0",
-        "symfony/http-foundation": "^5.3|^6.0|^7.0",
-        "symfony/http-kernel": "^5.3|^6.0|^7.0",
-        "symfony/routing": "^3.4|^4.0|^5.0|^6.0|^7.0"
+        "php": "8.0.*|8.1.*|8.2.*|8.3.*",
+        "symfony/config": "^6.0|^7.0",
+        "symfony/dependency-injection": "^6.0|^7.0",
+        "symfony/event-dispatcher": "^6.0|^7.0",
+        "symfony/http-foundation": "^6.0|^7.0",
+        "symfony/http-kernel": "^6.0|^7.0",
+        "symfony/routing": "^6.0|^7.0"
     },
 
     "require-dev": {

--- a/src/Bridge/SluggableInterface.php
+++ b/src/Bridge/SluggableInterface.php
@@ -13,8 +13,6 @@ interface SluggableInterface
      * Return null if the object does not have a slug (yet).
      * In that case, no validation will be performed and any
      * (dummy) slug will be accepted.
-     *
-     * @return ?string
      */
-    public function getSlug();
+    public function getSlug(): ?string;
 }

--- a/src/EventListener/ValidateSlugListener.php
+++ b/src/EventListener/ValidateSlugListener.php
@@ -28,13 +28,6 @@ class ValidateSlugListener implements EventSubscriberInterface
      */
     public const PRIORITY_AFTER_PARAM_CONVERTER_LISTENER = -1;
 
-    /**
-     * Generator that is used to create the redirect URLs.
-     *
-     * @var UrlGeneratorInterface
-     */
-    private $urlGenerator;
-
     public static function getSubscribedEvents(): array
     {
         return [
@@ -42,9 +35,9 @@ class ValidateSlugListener implements EventSubscriberInterface
         ];
     }
 
-    public function __construct(UrlGeneratorInterface $urlGenerator)
-    {
-        $this->urlGenerator = $urlGenerator;
+    public function __construct(
+        private UrlGeneratorInterface $urlGenerator
+    ) {
     }
 
     /**

--- a/tests/EventListener/ValidateSlugListenerTest.php
+++ b/tests/EventListener/ValidateSlugListenerTest.php
@@ -17,14 +17,9 @@ class ValidateSlugListenerTest extends TestCase
 {
     /**
      * System under test.
-     *
-     * @var ValidateSlugListener
      */
-    protected $listener;
+    protected ValidateSlugListener $listener;
 
-    /**
-     * Initializes the test environment.
-     */
     protected function setUp(): void
     {
         parent::setUp();
@@ -200,7 +195,9 @@ class ValidateSlugListenerTest extends TestCase
      */
     private function createController()
     {
-        return $this->getMockBuilder(\stdClass::class)->setMethods(['__invoke'])->getMock();
+        return $this->getMockBuilder(\stdClass::class)
+            ->onlyMethods(['__invoke'])
+            ->getMock();
     }
 
     /**

--- a/tests/EventListener/ValidateSlugListenerTest.php
+++ b/tests/EventListener/ValidateSlugListenerTest.php
@@ -193,7 +193,7 @@ class ValidateSlugListenerTest extends TestCase
      *
      * @return MockObject&callable
      */
-    private function createController()
+    private function createController(): MockObject
     {
         return $this->getMockBuilder(\stdClass::class)
             ->onlyMethods(['__invoke'])

--- a/tests/EventListener/ValidateSlugListenerTest.php
+++ b/tests/EventListener/ValidateSlugListenerTest.php
@@ -196,7 +196,7 @@ class ValidateSlugListenerTest extends TestCase
     private function createController(): MockObject
     {
         return $this->getMockBuilder(\stdClass::class)
-            ->onlyMethods(['__invoke'])
+            ->addMethods(['__invoke'])
             ->getMock();
     }
 


### PR DESCRIPTION
- Use PHP 8 syntax (Typed properties, constructor property promotion, ...) and replace deprecated method calls.
- Add return types
- Drop support of PHP < 8, which in turn means dropping support of Symfony < 6